### PR TITLE
Fix bug that was breaking passing relative paths for project paths

### DIFF
--- a/flexlate/config_manager.py
+++ b/flexlate/config_manager.py
@@ -76,8 +76,9 @@ class ConfigManager:
         return config
 
     def load_project_config(self, path: Path = Path(".")) -> ProjectConfig:
-        projects_config = self.load_projects_config(path=path)
-        return projects_config.get_project_for_path(path)
+        use_path = path.resolve()
+        projects_config = self.load_projects_config(path=use_path)
+        return projects_config.get_project_for_path(use_path)
 
     def save_projects_config(self, config: FlexlateProjectConfig):
         config.save()

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -2,9 +2,11 @@ from pathlib import Path
 
 from flexlate import Flexlate
 from flexlate.template.types import TemplateType
+from tests.config import GENERATED_FILES_DIR
 from tests.integration.fixtures.template_source import (
     COOKIECUTTER_CHANGES_TO_COPIER_LOCAL_FIXTURE,
     template_source_with_temp_dir_if_local_template,
+    COPIER_LOCAL_FIXTURE,
 )
 from tests.integration.fixtures.repo import *
 from tests.integration.template_source_checks import (
@@ -53,3 +55,48 @@ def test_update_template_from_cookiecutter_to_copier(
                 after_data_update=True,
             )
             assert_template_type_is(TemplateType.COPIER)
+
+
+def test_update_template_with_relative_path_from_outside_project(
+    repo_with_default_flexlate_project: Repo,
+):
+    update_from_dir = GENERATED_FILES_DIR / "something"
+    update_from_dir.mkdir()
+
+    project_dir = GENERATED_REPO_DIR
+
+    with template_source_with_temp_dir_if_local_template(
+        COPIER_LOCAL_FIXTURE
+    ) as template_source:
+        # First set up project so it can be updated
+        with change_directory_to(project_dir):
+            fxt.add_template_source(template_source.path)
+            fxt.apply_template_and_add(
+                template_source.name, data=template_source.input_data, no_input=True
+            )
+
+            # Check that files are correct
+            assert_root_template_source_output_is_correct(
+                template_source,
+                after_version_update=False,
+                after_data_update=False,
+            )
+
+            # Update local template
+            template_source.migrate_version(template_source.url_or_absolute_path)
+
+        # Now update from outside project
+        with change_directory_to(update_from_dir):
+            # Should be anle to directly update even though template type changes
+            fxt.update(
+                data=[template_source.update_input_data],
+                no_input=True,
+                project_path=Path("..") / "project",
+            )
+
+        # Check that files are correct
+        assert_root_template_source_output_is_correct(
+            template_source,
+            after_version_update=True,
+            after_data_update=True,
+        )


### PR DESCRIPTION
Now can update, etc. from outside the project with a relative path.